### PR TITLE
Create GitHub Action for VSCode Extension Publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish Extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run lint
+      run: npm run lint
+
+    - name: Run tests
+      run: npm test
+
+    - name: Run compile
+      run: npm run compile
+
+    - name: Package extension
+      run: npm run package
+
+    - name: Publish to VSCode Marketplace
+      run: npm run publish
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+    - name: Get package name and version
+      id: package_info
+      run: |
+        PACKAGE_NAME=$(node -p "require('./package.json').name")
+        PACKAGE_VERSION=$(node -p "require('./package.json').version")
+        echo "PACKAGE_NAME=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
+        echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ./${{ steps.package_info.outputs.PACKAGE_NAME }}-${{ steps.package_info.outputs.PACKAGE_VERSION }}.vsix
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow automatically publishes the extension to VSCode Marketplace and creates a GitHub Release when a version tag (v*) is pushed.

Features:
- Runs tests and linting before publishing
- Publishes to VSCode Marketplace using VSCE_PAT secret
- Creates GitHub Release with auto-generated release notes
- Uploads VSIX file to the release

To use this workflow:
1. Set up VSCE_PAT secret in repository settings
2. Push a version tag (e.g., git tag v0.0.6 && git push origin v0.0.6)

Generated with [Claude Code](https://claude.com/claude-code)