### PR TITLE
Fix: Add contents write permission for GitHub Release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The workflow was failing with 403 error when trying to create GitHub Release because GITHUB_TOKEN didn't have sufficient permissions.

Added permissions.contents: write to allow the workflow to create releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)