### PR TITLE
Add Open VSX publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,9 @@ jobs:
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
+    - name: Publish to Open VSX
+      run: npx ovsx publish --pat ${{ secrets.OVSX_PAT }}
+
     - name: Get package name and version
       id: package_info
       run: |


### PR DESCRIPTION
## Summary
- Add Open VSX Registry publishing step to the release workflow
- Extensions will now be published to both VS Code Marketplace and Open VSX when a new version tag is pushed
- Enables VSCodium, Cursor, and other VS Code fork users to install the extension

## Requirements
- `OVSX_PAT` secret must be configured in repository settings (already done)

## Test plan
- [x] Verify `OVSX_PAT` secret is set in repository settings
- [x] Create a new release tag to trigger the workflow
- [ ] Confirm extension appears on https://open-vsx.org/

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)